### PR TITLE
add the option to override the size, with just send an empty size prop

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -57,7 +57,7 @@
     },
     "ui/icon-button": {
         "scope": "teambit.design",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "mainFile": "index.ts",
         "rootDir": "src/ui/icon-button"
     },
@@ -93,7 +93,7 @@
     },
     "ui/settings-button": {
         "scope": "teambit.design",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "mainFile": "index.ts",
         "rootDir": "src/ui/settings-button"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,13 @@
 importers:
   .:
     dependencies:
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
       '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.input.button': registry.npmjs.org/@teambit/base-ui.input.button/1.0.1_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.input.checkbox.label': registry.npmjs.org/@teambit/base-ui.input.checkbox.label/1.0.1_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.styles.flex-center': registry.npmjs.org/@teambit/base-ui.styles.flex-center/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.surfaces.abs-container': registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/1.0.0_react-dom@17.0.2+react@17.0.2
-      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.0_react-dom@17.0.2+react@17.0.2
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.1_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.surfaces.drawer': registry.npmjs.org/@teambit/base-ui.surfaces.drawer/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.text.heading': registry.npmjs.org/@teambit/base-ui.text.heading/1.0.1_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes/1.0.0_react-dom@17.0.2+react@17.0.2
@@ -19,20 +20,19 @@ importers:
       '@teambit/toolbox.date.duration': 0.0.6
       '@types/react-router-dom': registry.npmjs.org/@types/react-router-dom/5.1.7
       classnames: registry.npmjs.org/classnames/2.3.1
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
       react-tabs: registry.npmjs.org/react-tabs/3.2.0_react@17.0.2
       reset-css: registry.npmjs.org/reset-css/5.0.1
-      typescript: registry.npmjs.org/typescript/4.3.4
+      typescript: registry.npmjs.org/typescript/4.3.5
     devDependencies:
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color/1.1.0_react-dom@17.0.2+react@17.0.2
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.2_react-dom@17.0.2+react@17.0.2
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color/0.1.0_react-dom@17.0.2+react@17.0.2
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.1_react-dom@17.0.2+react@17.0.2
       '@testing-library/react': registry.npmjs.org/@testing-library/react/11.2.2_react-dom@17.0.2+react@17.0.2
       '@types/jest': registry.npmjs.org/@types/jest/26.0.23
       '@types/node': registry.npmjs.org/@types/node/12.20.4
-      '@types/react': registry.npmjs.org/@types/react/17.0.11
+      '@types/react': registry.npmjs.org/@types/react/17.0.13
       '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.8
       '@types/react-tabs': registry.npmjs.org/@types/react-tabs/2.3.2
       '@types/testing-library__jest-dom': registry.npmjs.org/@types/testing-library__jest-dom/5.9.5
@@ -43,12 +43,12 @@ importers:
       '@teambit/base-ui.input.checkbox.label': ^1.0.1
       '@teambit/base-ui.styles.flex-center': ^1.0.0
       '@teambit/base-ui.surfaces.abs-container': ^1.0.0
-      '@teambit/base-ui.surfaces.card': ^1.0.0
+      '@teambit/base-ui.surfaces.card': ^1.0.1
       '@teambit/base-ui.surfaces.drawer': ^1.0.0
       '@teambit/base-ui.text.heading': ^1.0.1
       '@teambit/base-ui.text.text-sizes': ^1.0.0
-      '@teambit/base-ui.theme.accent-color': 1.1.0
-      '@teambit/base-ui.theme.dark-theme': 1.0.2
+      '@teambit/base-ui.theme.accent-color': 0.1.0
+      '@teambit/base-ui.theme.dark-theme': 1.0.1
       '@teambit/base-ui.theme.fonts.roboto': ^1.0.0
       '@teambit/base-ui.theme.theme-provider': ^1.0.1
       '@teambit/base-ui.time.duration': 0.0.17
@@ -59,18 +59,18 @@ importers:
       '@testing-library/react': 11.2.2
       '@types/jest': ^26.0.23
       '@types/node': 12.20.4
-      '@types/react': ^17.0.11
+      '@types/react': ^17.0.13
       '@types/react-dom': ^17.0.8
       '@types/react-router-dom': 5.1.7
       '@types/react-tabs': 2.3.2
       '@types/testing-library__jest-dom': 5.9.5
       classnames: ^2.3.1
-      core-js: ^3.15.1
+      core-js: ^3.15.2
       react: ^17.0.2
       react-dom: ^17.0.2
       react-tabs: 3.2.0
       reset-css: 5.0.1
-      typescript: ^4.3.4
+      typescript: ^4.3.5
   src/envs/react:
     specifiers: {}
   src/theme/icons-font:
@@ -177,7 +177,7 @@ packages:
       '@types/istanbul-lib-coverage': registry.npmjs.org/@types/istanbul-lib-coverage/2.0.3
       '@types/istanbul-reports': registry.npmjs.org/@types/istanbul-reports/3.0.1
       '@types/node': registry.npmjs.org/@types/node/12.20.4
-      '@types/yargs': registry.npmjs.org/@types/yargs/15.0.13
+      '@types/yargs': registry.npmjs.org/@types/yargs/15.0.14
       chalk: registry.npmjs.org/chalk/4.1.1
     engines:
       node: '>= 10.14.2'
@@ -189,7 +189,7 @@ packages:
     version: 26.6.2
   registry.npmjs.org/@teambit/base-ui.css-components.elevation/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -205,7 +205,7 @@ packages:
     version: 1.0.0
   registry.npmjs.org/@teambit/base-ui.css-components.roundness/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -222,7 +222,7 @@ packages:
   registry.npmjs.org/@teambit/base-ui.elements.dots-loader/1.0.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       classnames: registry.npmjs.org/classnames/2.3.1
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -290,7 +290,7 @@ packages:
     dependencies:
       '@teambit/base-ui.elements.dots-loader': registry.npmjs.org/@teambit/base-ui.elements.dots-loader/1.0.1_react-dom@17.0.2+react@17.0.2
       classnames: registry.npmjs.org/classnames/2.3.1
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -390,42 +390,42 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/-/base-ui.surfaces.abs-container-1.0.0.tgz
     version: 1.0.0
-  registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.0_react-dom@17.0.2+react@17.0.2:
+  registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
-    id: registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.0
+    id: registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.1
     name: '@teambit/base-ui.surfaces.background'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     resolution:
-      integrity: sha512-khRlQSpaS0OPM3rzlsazjS2i7IVDwr+3xdGOERO1OugNtLsc5vaGf7p9E8ismpQvK8moVcIGkOAiKPeS/Dqq2Q==
+      integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.background/-/base-ui.surfaces.background-1.0.0.tgz
-    version: 1.0.0
-  registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.0_react-dom@17.0.2+react@17.0.2:
+      tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.background/-/base-ui.surfaces.background-1.0.1.tgz
+    version: 1.0.1
+  registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@teambit/base-ui.css-components.elevation': registry.npmjs.org/@teambit/base-ui.css-components.elevation/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.css-components.roundness': registry.npmjs.org/@teambit/base-ui.css-components.roundness/1.0.0_react-dom@17.0.2+react@17.0.2
-      '@teambit/base-ui.surfaces.background': registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.0_react-dom@17.0.2+react@17.0.2
+      '@teambit/base-ui.surfaces.background': registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.1_react-dom@17.0.2+react@17.0.2
       classnames: registry.npmjs.org/classnames/2.3.1
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
-    id: registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.0
+    id: registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.1
     name: '@teambit/base-ui.surfaces.card'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     resolution:
-      integrity: sha512-enHQ4bYgaakzSa/hzcvgqd8ragQuSRMxPg/EwmxY6UWtpkYyYcF/uHGjV41IfhsO2yw7iVumFn1mdDkHY6QmsQ==
+      integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.card/-/base-ui.surfaces.card-1.0.0.tgz
-    version: 1.0.0
+      tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.card/-/base-ui.surfaces.card-1.0.1.tgz
+    version: 1.0.1
   registry.npmjs.org/@teambit/base-ui.surfaces.drawer/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@teambit/base-ui.hook.use-click-outside': registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/1.0.0_react-dom@17.0.2+react@17.0.2
@@ -448,7 +448,7 @@ packages:
     version: 1.0.0
   registry.npmjs.org/@teambit/base-ui.text.heading/1.0.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -495,26 +495,26 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/@teambit/base-ui.text.text/-/base-ui.text.text-0.0.17.tgz
     version: 0.0.17
-  registry.npmjs.org/@teambit/base-ui.theme.accent-color/1.1.0_react-dom@17.0.2+react@17.0.2:
+  registry.npmjs.org/@teambit/base-ui.theme.accent-color/0.1.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0_react-dom@17.0.2+react@17.0.2
-      core-js: registry.npmjs.org/core-js/3.15.1
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors/0.7.0_react-dom@17.0.2+react@17.0.2
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
-    id: registry.npmjs.org/@teambit/base-ui.theme.accent-color/1.1.0
+    id: registry.npmjs.org/@teambit/base-ui.theme.accent-color/0.1.0
     name: '@teambit/base-ui.theme.accent-color'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     resolution:
-      integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==
+      integrity: sha512-oCqQqI5b+eVO8FTbKXHFZfdSZaRfYVh0vyM2hvOoFPzg3ggNsM9N/jlljif+oWFL/k1avuDC2+sJg5VRcF3eQA==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/@teambit/base-ui.theme.accent-color/-/base-ui.theme.accent-color-1.1.0.tgz
-    version: 1.1.0
+      tarball: https://registry.npmjs.org/@teambit/base-ui.theme.accent-color/-/base-ui.theme.accent-color-0.1.0.tgz
+    version: 0.1.0
   registry.npmjs.org/@teambit/base-ui.theme.brand-definition/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -531,7 +531,7 @@ packages:
   registry.npmjs.org/@teambit/base-ui.theme.color-definition/1.0.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0_react-dom@17.0.2+react@17.0.2
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -545,9 +545,25 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/@teambit/base-ui.theme.color-definition/-/base-ui.theme.color-definition-1.0.1.tgz
     version: 1.0.1
+  registry.npmjs.org/@teambit/base-ui.theme.colors/0.7.0_react-dom@17.0.2+react@17.0.2:
+    dependencies:
+      core-js: registry.npmjs.org/core-js/3.15.2
+      react: registry.npmjs.org/react/17.0.2
+      react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
+    dev: true
+    id: registry.npmjs.org/@teambit/base-ui.theme.colors/0.7.0
+    name: '@teambit/base-ui.theme.colors'
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    resolution:
+      integrity: sha512-Tq2vl9byqyz9oHKu5D65n6Q4RqMnYxcw8Q06vbavVaC0TtQm5NbFXF6lft+2ruQjXhaC44ZA2QvL/8QSn+YxnA==
+      registry: https://node.bit.dev/
+      tarball: https://registry.npmjs.org/@teambit/base-ui.theme.colors/-/base-ui.theme.colors-0.7.0.tgz
+    version: 0.7.0
   registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     id: registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0
@@ -560,26 +576,26 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/@teambit/base-ui.theme.colors/-/base-ui.theme.colors-1.0.0.tgz
     version: 1.0.0
-  registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.2_react-dom@17.0.2+react@17.0.2:
+  registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.1_react-dom@17.0.2+react@17.0.2:
     dependencies:
       '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0_react-dom@17.0.2+react@17.0.2
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
-    id: registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.2
+    id: registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.1
     name: '@teambit/base-ui.theme.dark-theme'
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     resolution:
-      integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==
+      integrity: sha512-ZzpueHuGvQyyS0gPa8QGvZArA/vzMWHFu5wQGw8OlMwW/l5mZrIgLHni3EMiHkcxKKJEpXYvuSYzKZf7ynAlWg==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/@teambit/base-ui.theme.dark-theme/-/base-ui.theme.dark-theme-1.0.2.tgz
-    version: 1.0.2
+      tarball: https://registry.npmjs.org/@teambit/base-ui.theme.dark-theme/-/base-ui.theme.dark-theme-1.0.1.tgz
+    version: 1.0.1
   registry.npmjs.org/@teambit/base-ui.theme.fonts.book/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -611,7 +627,7 @@ packages:
     version: 1.0.0
   registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -627,7 +643,7 @@ packages:
     version: 1.0.0
   registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -643,7 +659,7 @@ packages:
     version: 1.0.0
   registry.npmjs.org/@teambit/base-ui.theme.size-definition/1.0.0_react-dom@17.0.2+react@17.0.2:
     dependencies:
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -666,7 +682,7 @@ packages:
       '@teambit/base-ui.theme.shadow-definition': registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.theme.size-definition': registry.npmjs.org/@teambit/base-ui.theme.size-definition/1.0.0_react-dom@17.0.2+react@17.0.2
       classnames: registry.npmjs.org/classnames/2.3.1
-      core-js: registry.npmjs.org/core-js/3.15.1
+      core-js: registry.npmjs.org/core-js/3.15.2
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
@@ -940,7 +956,7 @@ packages:
     version: 15.7.3
   registry.npmjs.org/@types/react-dom/17.0.8:
     dependencies:
-      '@types/react': registry.npmjs.org/@types/react/17.0.11
+      '@types/react': registry.npmjs.org/@types/react/17.0.13
     dev: true
     name: '@types/react-dom'
     resolution:
@@ -992,6 +1008,18 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/@types/react/-/react-17.0.11.tgz
     version: 17.0.11
+  registry.npmjs.org/@types/react/17.0.13:
+    dependencies:
+      '@types/prop-types': registry.npmjs.org/@types/prop-types/15.7.3
+      '@types/scheduler': registry.npmjs.org/@types/scheduler/0.16.1
+      csstype: registry.npmjs.org/csstype/3.0.8
+    dev: true
+    name: '@types/react'
+    resolution:
+      integrity: sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==
+      registry: https://node.bit.dev/
+      tarball: https://registry.npmjs.org/@types/react/-/react-17.0.13.tgz
+    version: 17.0.13
   registry.npmjs.org/@types/scheduler/0.16.1:
     name: '@types/scheduler'
     resolution:
@@ -1009,22 +1037,22 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz
     version: 5.9.5
-  registry.npmjs.org/@types/yargs-parser/20.2.0:
+  registry.npmjs.org/@types/yargs-parser/20.2.1:
     name: '@types/yargs-parser'
     resolution:
-      integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
+      integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz
-    version: 20.2.0
-  registry.npmjs.org/@types/yargs/15.0.13:
+      tarball: https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz
+    version: 20.2.1
+  registry.npmjs.org/@types/yargs/15.0.14:
     dependencies:
-      '@types/yargs-parser': registry.npmjs.org/@types/yargs-parser/20.2.0
+      '@types/yargs-parser': registry.npmjs.org/@types/yargs-parser/20.2.1
     name: '@types/yargs'
     resolution:
-      integrity: sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+      integrity: sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz
-    version: 15.0.13
+      tarball: https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz
+    version: 15.0.14
   registry.npmjs.org/ansi-regex/5.0.0:
     engines:
       node: '>=8'
@@ -1198,6 +1226,7 @@ packages:
       tarball: https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.1.tgz
     version: 3.15.1
   registry.npmjs.org/core-js/3.15.1:
+    dev: false
     name: core-js
     requiresBuild: true
     resolution:
@@ -1205,6 +1234,14 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/core-js/-/core-js-3.15.1.tgz
     version: 3.15.1
+  registry.npmjs.org/core-js/3.15.2:
+    name: core-js
+    requiresBuild: true
+    resolution:
+      integrity: sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==
+      registry: https://node.bit.dev/
+      tarball: https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz
+    version: 3.15.2
   registry.npmjs.org/core-util-is/1.0.2:
     dev: false
     name: core-util-is
@@ -1622,17 +1659,17 @@ packages:
       registry: https://node.bit.dev/
       tarball: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz
     version: 7.2.0
-  registry.npmjs.org/typescript/4.3.4:
+  registry.npmjs.org/typescript/4.3.5:
     dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true
     name: typescript
     resolution:
-      integrity: sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+      integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
       registry: https://node.bit.dev/
-      tarball: https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz
-    version: 4.3.4
+      tarball: https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz
+    version: 4.3.5
   registry.npmjs.org/universalify/0.1.2:
     dev: false
     engines:

--- a/src/ui/icon-button/icon-button.compositions.tsx
+++ b/src/ui/icon-button/icon-button.compositions.tsx
@@ -42,6 +42,10 @@ export function ActiveWithIconButtonExample() {
   );
 }
 
+export function SmallActiveIconOnlyWithOverrideSize() {
+  return <IconButton icon="plus" active size={null} style={{ width: 24, height: 24, justifyContent: 'center' }} />;
+}
+
 export function DefaultButton() {
   return <IconButton priority="ghost">Update</IconButton>;
 }

--- a/src/ui/icon-button/icon-button.tsx
+++ b/src/ui/icon-button/icon-button.tsx
@@ -25,7 +25,7 @@ export type IconButtonProps = {
   /**
    * button sizes
    */
-  size?: 'm' | 'l';
+  size?: 'm' | 'l' | '';
 } & ButtonProps;
 
 /**

--- a/src/ui/icon-button/icon-button.tsx
+++ b/src/ui/icon-button/icon-button.tsx
@@ -25,7 +25,7 @@ export type IconButtonProps = {
   /**
    * button sizes
    */
-  size?: 'm' | 'l' | '';
+  size?: 'm' | 'l' | null;
 } & ButtonProps;
 
 /**


### PR DESCRIPTION
I need this option for this block, I want to use this button because he already handle everything and this is our new button for everywhere.
![image](https://user-images.githubusercontent.com/35892475/124454356-10fdd880-dd91-11eb-99cd-33257dffa083.png)

For this example, I use it like this:
```
<IconButton icon="plus" active size="" className={styles.iconHolder} />
```
and send and height via the className.
If we not set this new option, we can't send a different height, because the component have a default size. (and we want to keep the default size for everywhere else)