### PR TITLE
Deprecate ui/input/icon-text. Rename ui/input/text to inputs/input-text.

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -29,31 +29,37 @@
     },
     "inputs/dropdown": {
         "scope": "teambit.design",
-        "version": "1.1.0",
+        "version": "1.1.1",
         "mainFile": "index.ts",
         "rootDir": "src/inputs/dropdown"
     },
+    "inputs/input-text": {
+        "scope": "teambit.design",
+        "version": "0.0.2",
+        "mainFile": "index.ts",
+        "rootDir": "src/inputs/input-text"
+    },
     "inputs/selectors/checkbox-item": {
         "scope": "teambit.design",
-        "version": "1.1.0",
+        "version": "1.1.1",
         "mainFile": "index.ts",
         "rootDir": "src/inputs/selectors/checkbox-item"
     },
     "inputs/selectors/menu-item": {
         "scope": "teambit.design",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "mainFile": "index.ts",
         "rootDir": "src/inputs/selectors/menu-item"
     },
     "inputs/selectors/multi-select": {
         "scope": "teambit.design",
-        "version": "1.1.1",
+        "version": "1.1.3",
         "mainFile": "index.ts",
         "rootDir": "src/inputs/selectors/multi-select"
     },
     "surfaces/selectable": {
         "scope": "teambit.design",
-        "version": "0.0.13",
+        "version": "0.0.14",
         "mainFile": "index.ts",
         "rootDir": "src/ui/surfaces/selectable"
     },
@@ -77,55 +83,55 @@
     },
     "ui/avatar": {
         "scope": "teambit.design",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "src/ui/avatar"
     },
     "ui/color-border": {
         "scope": "teambit.design",
-        "version": "1.0.15",
+        "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "src/ui/color-border"
     },
     "ui/css/menu-transition": {
         "scope": "teambit.design",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "mainFile": "index.ts",
         "rootDir": "src/ui/css/menu-transition"
     },
     "ui/dropdown": {
         "scope": "teambit.design",
-        "version": "2.0.2",
+        "version": "2.0.3",
         "mainFile": "index.ts",
         "rootDir": "src/ui/dropdown"
     },
     "ui/heading": {
         "scope": "teambit.design",
-        "version": "1.0.15",
+        "version": "1.0.16",
         "mainFile": "index.tsx",
         "rootDir": "src/ui/heading"
     },
     "ui/hoverable": {
         "scope": "teambit.design",
-        "version": "1.0.14",
+        "version": "1.0.15",
         "mainFile": "index.ts",
         "rootDir": "src/ui/hoverable"
     },
     "ui/icon-button": {
         "scope": "teambit.design",
-        "version": "1.1.5",
+        "version": "1.1.6",
         "mainFile": "index.ts",
         "rootDir": "src/ui/icon-button"
     },
     "ui/input/color-picker": {
         "scope": "teambit.design",
-        "version": "0.0.36",
+        "version": "0.0.37",
         "mainFile": "index.ts",
         "rootDir": "src/ui/input/color-picker"
     },
     "ui/input/icon-text": {
         "scope": "teambit.design",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "src/ui/input/icon-text"
     },
@@ -143,7 +149,7 @@
     },
     "ui/input/text": {
         "scope": "teambit.design",
-        "version": "1.0.2",
+        "version": "1.0.3",
         "mainFile": "index.ts",
         "rootDir": "src/ui/input/text"
     },
@@ -161,7 +167,7 @@
     },
     "ui/owner-avatar": {
         "scope": "teambit.design",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "src/ui/owner-avatar"
     },
@@ -179,7 +185,7 @@
     },
     "ui/settings-button": {
         "scope": "teambit.design",
-        "version": "1.1.5",
+        "version": "1.1.6",
         "mainFile": "index.ts",
         "rootDir": "src/ui/settings-button"
     },

--- a/src/inputs/input-text/index.ts
+++ b/src/inputs/input-text/index.ts
@@ -1,0 +1,2 @@
+export { InputText, InputTextArea } from './input-text';
+export type { InputTextProps, InputTextAreaProps } from './input-text';

--- a/src/inputs/input-text/input-text.composition.tsx
+++ b/src/inputs/input-text/input-text.composition.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { darkMode } from '@teambit/base-ui.theme.dark-theme';
+import { Icon } from '@teambit/design.elements.icon';
+import { InputText, InputTextArea } from './input-text';
+
+export const InputTextExample = () => <InputText placeholder="enter text..." data-testid="test-input" />;
+
+export const FilledInputTextExample = () => <InputText value="some text" filled data-testid="test-input" />;
+
+export const ErrorInputText = () => <InputText error data-testid="test-input" />;
+
+export const SuccessInputText = () => <InputText success data-testid="test-input" />;
+
+export const DisabledInputText = () => {
+  return <InputText placeholder="placeholder..." disabled data-testid="test-input" />;
+};
+
+export const SmallInputText = () => (
+  <InputText style={{ fontSize: 12 }} placeholder="enter text..." data-testid="test-input" />
+);
+
+export const BigInputText = () => (
+  <InputText style={{ fontSize: 24 }} placeholder="enter text..." data-testid="test-input" />
+);
+
+export const InputTextDarkMode = () => (
+  <div className={darkMode} style={{ padding: '20px 40px', backgroundColor: '#0c0c0c' }}>
+    <InputText placeholder="enter text..." data-testid="test-input" />
+  </div>
+);
+
+export const InputTextWithIcon = () => (
+  <InputText
+    placeholder="search..."
+    icon={<Icon of="discovery" style={{ cursor: 'pointer' }} onClick={() => alert('on icon click')} />}
+  />
+);
+
+export const InputTextWithImage = () => (
+  <InputText
+    placeholder="search..."
+    icon={
+      <img
+        src="https://static.bit.dev/bit-icons/filter.svg"
+        style={{ cursor: 'pointer' }}
+        onClick={() => alert('on icon click')}
+      />
+    }
+  />
+);
+
+export const InputTextAreaExample = () => <InputTextArea placeholder="multiline text..." data-testid="test-textarea" />;
+
+export const ErrorInputTextArea = () => <InputTextArea error data-testid="test-textarea" />;
+
+export const SuccessInputTextArea = () => <InputTextArea success data-testid="test-textarea" />;
+
+export const DisabledInputTextArea = () => (
+  <InputTextArea placeholder="placeholder..." disabled data-testid="test-textarea" />
+);

--- a/src/inputs/input-text/input-text.docs.mdx
+++ b/src/inputs/input-text/input-text.docs.mdx
@@ -1,0 +1,39 @@
+---
+labels: ['react', 'typescript', 'input', 'text-area']
+description: 'Input text and text-area components.'
+---
+
+import { useState } from 'react';
+import { InputText } from './input-text';
+
+### Usages
+
+InputText and InputTextArea components with error and success props.  
+Supports all props from native html input and textarea.  
+Size support with em, the container of the component can use `font-size` to change the size of the component.
+
+InputText example:
+
+```js live
+() => {
+  const [value, setValue] = useState('');
+  return (
+    <InputText error={value === 'error'} success={value === 'success'} onChange={(e) => setValue(e.target.value)} />
+  );
+};
+```
+
+InputText with icon:
+
+```js live
+<InputText
+  placeholder="search..."
+  icon={
+    <img
+      src="https://static.bit.dev/bit-icons/filter.svg"
+      style={{ cursor: 'pointer' }}
+      onClick={() => alert('on icon click')}
+    />
+  }
+/>
+```

--- a/src/inputs/input-text/input-text.module.scss
+++ b/src/inputs/input-text/input-text.module.scss
@@ -1,0 +1,62 @@
+.inputText {
+  width: 100%;
+  box-sizing: border-box;
+  outline: 0;
+  padding: 0.69em 1em;
+  font-size: inherit;
+  font-family: inherit;
+  border-radius: 8px;
+  border: 1px solid var(--bit-border-color-lightest, #ededed);
+  background-color: var(--bit-bg-tooltip, #ffffff);
+  color: var(--bit-text-color-heavy, #2b2b2b);
+
+  // keep precedence! filled < hover < success < error < disabled
+  &.filled {
+    background-color: var(--bit-bg-dent, #f6f6f6);
+  }
+  &::placeholder {
+    color: var(--bit-text-color-light, #6c707c);
+  }
+  &:hover {
+    border: 1px solid var(--bit-text-inactive, #babec9);
+  }
+  &:focus {
+    border-color: transparent;
+    background-color: var(--bit-bg-tooltip, #ffffff);
+    box-shadow: var(--bit-shadow-raised-low, 0 -1px 1px 0 rgba(0, 0, 0, 0.09), 0 2px 2px 0 rgba(0, 0, 0, 0.23));
+  }
+  &.success {
+    background-color: var(--positive-surface-color, var(--bit-accent-bg, #eefaf3));
+    border: 1px solid var(--positive-color, var(--bit-accent-color, #37b26c));
+  }
+  &.error {
+    background-color: var(--negative-surface-color, var(--bit-accent-bg, #fdeff2));
+    border: 1px solid var(--negative-color, var(--bit-accent-color, #e62e5c));
+  }
+  &:disabled {
+    cursor: not-allowed;
+    background-color: var(--bit-bg-dent, #f6f6f6);
+    color: var(--bit-text-inactive, #babec9);
+    border: 1px solid var(--bit-border-color-lightest, #ededed);
+  }
+}
+
+.inputTextWithIcon {
+  position: relative;
+  font-size: inherit;
+  .inputText {
+    padding-right: 2em;
+  }
+  > :last-child {
+    font-size: inherit;
+    color: inherit;
+    position: absolute;
+    right: 0.75em;
+    top: 0.75em;
+    width: 16px;
+  }
+}
+
+.inputTextArea {
+  resize: none;
+}

--- a/src/inputs/input-text/input-text.spec.tsx
+++ b/src/inputs/input-text/input-text.spec.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  InputTextExample,
+  ErrorInputText,
+  SuccessInputText,
+  DisabledInputText,
+  InputTextAreaExample,
+  ErrorInputTextArea,
+  SuccessInputTextArea,
+  DisabledInputTextArea,
+  InputTextWithImage,
+} from './input-text.composition';
+
+describe('InputText component', () => {
+  it('should render input correctly', () => {
+    const { getByTestId } = render(<InputTextExample />);
+    const rendered = getByTestId('test-input');
+
+    expect(rendered).toBeInTheDocument();
+    expect(rendered.tagName).toBe('INPUT');
+  });
+
+  it('should not have error or success styles', () => {
+    const { getByTestId } = render(<InputTextExample />);
+    const rendered = getByTestId('test-input');
+
+    expect(rendered.classList.contains('success')).toBeFalsy();
+    expect(rendered.classList.contains('error')).toBeFalsy();
+  });
+
+  it('should have error class', () => {
+    const { getByTestId } = render(<ErrorInputText />);
+    const rendered = getByTestId('test-input');
+
+    expect(rendered.classList.contains('error')).toBeTruthy();
+  });
+
+  it('should have success class', () => {
+    const { getByTestId } = render(<SuccessInputText />);
+    const rendered = getByTestId('test-input');
+
+    expect(rendered.classList.contains('success')).toBeTruthy();
+  });
+
+  it('should have disabled attribute', () => {
+    const { getByTestId } = render(<DisabledInputText />);
+    const rendered = getByTestId('test-input');
+
+    expect(rendered.getAttribute('disabled')).toBe('');
+  });
+});
+
+describe('InputText component with icon', () => {
+  it('should have img tag', () => {
+    const { container } = render(<InputTextWithImage />);
+
+    expect(container.querySelector('img')).toBeInTheDocument();
+  });
+});
+
+describe('InputTextArea component', () => {
+  it('should render text-area correctly', () => {
+    const { getByTestId } = render(<InputTextAreaExample />);
+    const rendered = getByTestId('test-textarea');
+
+    expect(rendered).toBeInTheDocument();
+    expect(rendered.tagName).toBe('TEXTAREA');
+  });
+
+  it('should not have error or success styles', () => {
+    const { getByTestId } = render(<InputTextAreaExample />);
+    const rendered = getByTestId('test-textarea');
+
+    expect(rendered.classList.contains('success')).toBeFalsy();
+    expect(rendered.classList.contains('error')).toBeFalsy();
+  });
+
+  it('should have error class', () => {
+    const { getByTestId } = render(<ErrorInputTextArea />);
+    const rendered = getByTestId('test-textarea');
+
+    expect(rendered.classList.contains('error')).toBeTruthy();
+  });
+
+  it('should have success class', () => {
+    const { getByTestId } = render(<SuccessInputTextArea />);
+    const rendered = getByTestId('test-textarea');
+
+    expect(rendered.classList.contains('success')).toBeTruthy();
+  });
+
+  it('should have disabled attribute', () => {
+    const { getByTestId } = render(<DisabledInputTextArea />);
+    const rendered = getByTestId('test-textarea');
+
+    expect(rendered.getAttribute('disabled')).toBe('');
+  });
+});

--- a/src/inputs/input-text/input-text.tsx
+++ b/src/inputs/input-text/input-text.tsx
@@ -1,0 +1,75 @@
+import React, { forwardRef, ReactElement } from 'react';
+import classNames from 'classnames';
+import { colorPalette } from '@teambit/base-ui.theme.accent-color';
+import styles from './input-text.module.scss';
+
+type Props = {
+  /**
+   * error style
+   */
+  error?: boolean;
+  /**
+   * success style
+   */
+  success?: boolean;
+  /**
+   * filled style
+   */
+  filled?: boolean;
+};
+
+export type InputTextProps = {
+  /**
+   * An optional Icon element to be render at the end of the input, can be an Image or an Icon.
+   */
+  icon?: ReactElement;
+} & Props &
+  React.InputHTMLAttributes<HTMLInputElement>;
+
+export type InputTextAreaProps = Props & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const getAccent = ({ error, success }: Props) => {
+  return (
+    (error && classNames(colorPalette.error, styles.error)) ||
+    (success && classNames(colorPalette.success, styles.success))
+  );
+};
+
+export const InputText = forwardRef<HTMLInputElement, InputTextProps>(function InputTextWithRef(
+  { className, style, error, success, filled, icon, ...rest }: InputTextProps,
+  ref
+) {
+  const accent = getAccent({ error, success });
+
+  if (icon)
+    return (
+      <div className={classNames(styles.inputTextWithIcon, className)} style={style}>
+        <input ref={ref} className={classNames(styles.inputText, filled && styles.filled, accent)} {...rest} />
+        {icon}
+      </div>
+    );
+
+  return (
+    <input
+      ref={ref}
+      className={classNames(styles.inputText, filled && styles.filled, accent, className)}
+      style={style}
+      {...rest}
+    />
+  );
+});
+
+export const InputTextArea = forwardRef<HTMLTextAreaElement, InputTextAreaProps>(function InputTextAreaWithRef(
+  { className, error, success, filled, ...rest }: InputTextAreaProps,
+  ref
+) {
+  const accent = getAccent({ error, success });
+
+  return (
+    <textarea
+      ref={ref}
+      className={classNames(styles.inputText, styles.inputTextArea, filled && styles.filled, accent, className)}
+      {...rest}
+    />
+  );
+});

--- a/src/inputs/selectors/multi-select/multi-select.module.scss
+++ b/src/inputs/selectors/multi-select/multi-select.module.scss
@@ -19,7 +19,4 @@
 }
 .searchInput {
   margin: 4px 16px 16px;
-  .icon {
-    width: 16px;
-  }
 }

--- a/src/inputs/selectors/multi-select/search-input.tsx
+++ b/src/inputs/selectors/multi-select/search-input.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
-import { IconTextInput, IconTextInputProps } from '@teambit/design.ui.input.icon-text';
+import { InputText, InputTextProps } from '@teambit/design.inputs.input-text';
 import styles from './multi-select.module.scss';
 
-export function SearchInput({ className, ...rest }: IconTextInputProps) {
+export function SearchInput({ className, ...rest }: InputTextProps) {
   return (
-    <IconTextInput
+    <InputText
       className={classNames(styles.searchInput, className)}
       placeholder="Search"
-      icon={<img className={styles.icon} src="https://static.bit.dev/bit-icons/magnifying-glass.svg" />}
+      icon={<img src="https://static.bit.dev/bit-icons/magnifying-glass.svg" />}
       {...rest}
     />
   );


### PR DESCRIPTION
- Deprecate ui/input/icon-text. Rename ui/input/text to inputs/input-text and add the icon option.
-  Update multi-select to use the new input-text.